### PR TITLE
fix: BibTeX closing brace and reference utils/helpers.py not memory_u…

### DIFF
--- a/.github/ISSUE_TEMPLATE/implement_technique.md
+++ b/.github/ISSUE_TEMPLATE/implement_technique.md
@@ -25,7 +25,7 @@ Briefly describe your approach to implementing this technique:
 - [ ] Read the existing skeleton notebook and README
 - [ ] Implementation follows the notebook structure (Introduction, Concept, Implementation, Demo, Exercises)
 - [ ] Code runs end-to-end without errors
-- [ ] Uses `utils/memory_utils.py` for shared functionality where applicable
+- [ ] Uses `utils/helpers.py` for shared functionality where applicable
 - [ ] Tested with at least one LLM provider (OpenAI or Anthropic)
 
 ---

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ If you use this repository in your research or teaching, please cite:
     title={Agent Memory Techniques: A Comprehensive Collection},
     author={Nir Diamant},
     year={2026},
-    url={https://github.com/NirDiamant/Agent_Memory_Techniques
+    url={https://github.com/NirDiamant/Agent_Memory_Techniques}
 }
 ```
 


### PR DESCRIPTION
## Summary

Fixes two broken/invalid references found during a repo audit:
- **BibTeX citation in README.md**: The `url` field was missing its closing `}`, producing invalid BibTeX syntax.
- **Issue template implement_technique.md**: Checklist referenced non-existent `utils/memory_utils.py` instead of `utils/helpers.py`.

## Type of change

- [ ] New technique implementation
- [x] Bug fix
- [x] Documentation improvement
- [ ] Utility / infrastructure
- [ ] Other:

## Technique(s) affected

N/A — repository infrastructure only

## Checklist

- [x] Notebook runs end-to-end without errors *(N/A — no notebook changes)*
- [ ] README is updated if needed
- [x] No API keys or secrets are committed
- [x] Code follows existing patterns in the repo
- [x] Self-review completed

## Test instructions

- Verify the BibTeX block in README.md renders correctly (line 437-444): the `url` field should close with `}`.
- Verify `.github/ISSUE_TEMPLATE/implement_technique.md` references `utils/helpers.py` not `utils/memory_utils.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed citation formatting in README for improved readability.
  * Updated issue template guidance references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->