### PR TITLE
fix: add missing CITATION.cff fields and align bibtex title

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,8 @@
 cff-version: 1.2.0
 message: "If you use this repository, please cite it as below."
 title: "Agent Memory Techniques: A Cookbook for LLM Agent Memory"
+version: "1.0.0"
+date-released: "2026-05-05"
 authors:
   - family-names: "Diamant"
     given-names: "Nir"

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ If you use this repository in your research or teaching, please cite:
 
 ```bibtex
 @misc{diamant2026agentmemory,
-    title={Agent Memory Techniques: A Comprehensive Collection},
+    title={Agent Memory Techniques: A Cookbook for LLM Agent Memory},
     author={Nir Diamant},
     year={2026},
     url={https://github.com/NirDiamant/Agent_Memory_Techniques


### PR DESCRIPTION
## Summary

Fixes two inconsistencies in the citation metadata:

### 1. Missing recommended fields in `CITATION.cff`
The [CFF 1.2.0 spec](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md) marks `version` and `date-released` as **recommended**. GitHub shows a warning icon in the sidebar's "Cite this repository" panel when `date-released` is absent, and the generated APA/BibTeX output is incomplete without it.

**Added:**
- `version: "1.0.0"` (the repo has shipped all 30 techniques — 1.0.0 is appropriate)
- `date-released: "2026-05-05"` (matches the repository creation date from the GitHub API)

### 2. Title mismatch between `CITATION.cff` and the `README.md` BibTeX block

| Location | Title |
|---|---|
| `CITATION.cff` (canonical) | *A Cookbook for LLM Agent Memory* |
| `README.md` `@misc` block (before this PR) | *A Comprehensive Collection* |

`CITATION.cff` is the authoritative source (it's what GitHub's "Cite this repository" button uses). The BibTeX block in `README.md` now matches it.

Note: this PR is independent of open PR #1, which fixes the BibTeX `url` closing brace and a template file reference — different lines, no conflict.

## Type of change

- [x] Bug fix
- [x] Documentation improvement

## Technique(s) affected

N/A — repository infrastructure only

## Checklist

- [x] `utils/validate_style.py` passes (no banned words or dashes introduced)
- [x] `utils/validate_cells.py` passes
- [x] No notebook or code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project citation metadata with a release version and release date.
  * Refined the citation title in the README to better reflect the current project name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->