### PR TITLE
docs(26): remove letta package from prerequisites table

### DIFF
--- a/all_techniques/26_letta_memgpt_patterns/README.md
+++ b/all_techniques/26_letta_memgpt_patterns/README.md
@@ -8,7 +8,7 @@
 
 | Difficulty | Time | Prerequisites |
 |------------|------|---------------|
-| Advanced | ~55 min | Python 3.8+, `OPENAI_API_KEY`, `letta` package, understanding of 12 Working Memory recommended |
+| Advanced | ~55 min | Python 3.8+, `OPENAI_API_KEY`, understanding of 12 Working Memory recommended |
 
 This technique is for developers interested in MemGPT-style memory management where the agent controls its own memory reads and writes through function calls.
 


### PR DESCRIPTION
## What

The prerequisites table in `all_techniques/26_letta_memgpt_patterns/README.md` listed ```letta``` as a required package.

## Why it's wrong

I checked the notebook (`letta_memgpt_patterns.ipynb`) — it builds the MemGPT architecture from scratch using only `openai`, `python-dotenv`, and `numpy` (see the single `%pip install` cell). There is no `import letta` or `letta-client` usage in any runnable code cell. Installing `letta` is not needed to run the notebook.

## How I verified

- Fetched the notebook from `raw.githubusercontent.com` and scanned every code cell for `pip install` and `import` statements.
- Confirmed the only install is: `%pip install -q openai python-dotenv numpy`
- Confirmed zero occurrences of `letta` in any code cell source.

## Fix

One-line removal of ```letta``` package from the prerequisites row. Nothing else changed.

---

*Spotted this while reading through the technique READMEs. Happy to adjust if the notebook is expected to use the SDK in a future update — just let me know.*

— Siri

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the prerequisites for the Letta/MemGPT patterns guide.
  * Clarified that installing the Letta package is no longer required; other prerequisites remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->