### PR TITLE
README: feature Agent Memory Made Simple in the book section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,15 @@ One `npm install` adds the module's AI assistant to your Claude Code, and it gui
 
 </div>
 
-## 📖 Go deeper on RAG
+## 📖 The book of this repo
 
 <div align="center">
 
-<a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agent-memory-techniques--readme&amp;click=book-buy-gumroad-rag-image&amp;target=https%3A%2F%2Fdiamant-ai.com%2Frag-made-simple%3Fcode%3DRAGKING&amp;retarget=0&amp;text=book-buy-gumroad-rag-image"><img src="images/rag_book_best_seller.png" alt="RAG Made Simple" width="360"></a>
+**[Agent Memory Made Simple](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agent-memory-techniques--readme&click=book-buy-gumroad-am-cta&target=https%3A%2F%2Fdiamant-ai.com%2Fagent-memory-made-simple&retarget=0&text=book-buy-gumroad-am-cta)** - the 464-page visual guide to everything in this repo: all 30 techniques, 184 custom illustrations, zero code required.
 
-**[RAG Made Simple](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agent-memory-techniques--readme&click=book-buy-gumroad-rag-cta&target=https%3A%2F%2Fdiamant-ai.com%2Frag-made-simple%3Fcode%3DRAGKING&retarget=0&text=book-buy-gumroad-rag-cta)** - the 400-page visual guide to RAG, by the author of this repo.
-Amazon Bestseller in Generative AI · 1,500+ readers · ⭐ 4.6
+**[Get it - direct from the author →](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agent-memory-techniques--readme&click=book-buy-gumroad-am-cta&target=https%3A%2F%2Fdiamant-ai.com%2Fagent-memory-made-simple&retarget=0&text=book-buy-gumroad-am-cta)** · [Prefer Amazon or Kindle Unlimited?](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agent-memory-techniques--readme&click=book-buy-amazon-am-cta&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0HCRMGHCM%3Fmaas%3Dmaas_adg_api_580351185840460851_static_9_573%26ref_%3Daa_maas%26tag%3Dmaas%26aa_campaignid%3Dam-en%26aa_adgroupid%3Dgithub-readme%26aa_creativeid%3Dbook-section&retarget=0&text=book-buy-amazon-am-cta)
 
-**[Get it - 33% off with code RAGKING →](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agent-memory-techniques--readme&click=book-buy-gumroad-rag-cta&target=https%3A%2F%2Fdiamant-ai.com%2Frag-made-simple%3Fcode%3DRAGKING&retarget=0&text=book-buy-gumroad-rag-cta)** · [Read Chapter 1 free](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agent-memory-techniques--readme&click=free-chapter&target=https%3A%2F%2Fdiamant-ai.com%2Frag-made-simple%2Fchapter-1&retarget=0&text=free-chapter)
+**More from the series:** [RAG Made Simple](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agent-memory-techniques--readme&click=book-buy-gumroad-rag-cta&target=https%3A%2F%2Fdiamant-ai.com%2Frag-made-simple%3Fcode%3DRAGKING&retarget=0&text=book-buy-gumroad-rag-cta) - Amazon Bestseller in Generative AI · 1,500+ readers · ⭐ 4.6 · [33% off with code RAGKING](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=agent-memory-techniques--readme&click=book-buy-gumroad-rag-cta&target=https%3A%2F%2Fdiamant-ai.com%2Frag-made-simple%3Fcode%3DRAGKING&retarget=0&text=book-buy-gumroad-rag-cta)
 
 </div>
 


### PR DESCRIPTION
The 📖 book section of this README was promoting **RAG Made Simple** only — this repo's own companion book wasn't mentioned.

This PR:
- Leads with **Agent Memory Made Simple** (the 464-page companion to these 30 notebooks): direct-from-author link plus an Amazon/Kindle-Unlimited option (Amazon link carries an Attribution tag so channel conversion becomes measurable)
- Keeps RAG Made Simple as a compact **series cross-sell** line with the existing RAGKING code
- Uses the same click-tracker pattern as every other link in this README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the “Go deeper on RAG” section with a new “The book of this repo” section.
  * Added links to *Agent Memory Made Simple* and *RAG Made Simple*.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->